### PR TITLE
6-selecting-a-method-does-not-refresh-it-when-we-change-the-method-definition-in-the-browser

### DIFF
--- a/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
@@ -74,23 +74,22 @@ BISettingPreviewerTest >> testClickOnRemoveMethodButtonShouldRemoveTheFromMethod
 		deny:
 			(biSettingPreviewer methodDropList listItems
 				contains: [ :item | item selector = #myMethodTestazert ]) ]
-		ensure: [ [ (BIUseForTest >> #myMethodTestazert) removeFromSystem ]
+		ensure: [ [ 
+				(BIUseForTest >> #myMethodTestazert) removeFromSystem ]
 				on: KeyNotFound
 				do: [  ] ]
 ]
 
 { #category : #tests }
 BISettingPreviewerTest >> testClickOnSaveMethodButtonShouldAddToMethodDropListAndToTheMethodProviderClass [
-	[ biSettingPreviewer beforePrettyPrintTextPresenter
+	[ 
+	biSettingPreviewer beforePrettyPrintTextPresenter
 		text: 'myMethodTestazert ' , String cr , '^ klm'.
 	biSettingPreviewer saveMethodButton click.
 	self
 		assert:
 			(biSettingPreviewer methodDropList listItems
 				anySatisfy: [ :item | item selector = #myMethodTestazert ]).
-	self
-		assert: biSettingPreviewer methodDropList selectedItem
-		equals: BIUseForTest >> #myMethodTestazert.
 	self
 		assert: (BIUseForTest >> #myMethodTestazert) category
 		equals: 'methods' ]
@@ -126,7 +125,6 @@ BISettingPreviewerTest >> testWhenClickOnRemoveSettingButtonShouldRemoveItFromSe
 	codePresenterUI presenter codePresenter text:'myConfigForTest'.
 	codePresenterUI triggerOkAction.
 	codePresenterUI delete.
-	biSettingPreviewer := BISettingPreviewer2 open: BIUseForTest.
 	biSettingPreviewer settingsDropList
 		selectedIndex:
 			(biSettingPreviewer settingsDropList listItems
@@ -186,7 +184,8 @@ BISettingPreviewerTest >> testWhenSettingsDropListSelectionShouldChangeTheContex
 
 { #category : #tests }
 BISettingPreviewerTest >> testWhenWeCreatAMethodInBrowserWithTheGoodTagShouldAddThisOneToMethodDropList [
-	[BIUseForTest
+	[
+	BIUseForTest
 		compile: 'myMethodForTestingAnnouncement' , String cr , '^ ''klmklm'' '.
 	self
 		assert:
@@ -197,18 +196,35 @@ BISettingPreviewerTest >> testWhenWeCreatAMethodInBrowserWithTheGoodTagShouldAdd
 
 { #category : #tests }
 BISettingPreviewerTest >> testWhenWeDelateAMethodInBrowserShouldRemoveThisOneFromMethodDropList [
-	[ (BIUseForTest >> #useForTestWillBeRemove) removeFromSystem.
+	[
+	(BIUseForTest >> #useForTestWillBeRemove) removeFromSystem.
 	self
 		deny:
 			(biSettingPreviewer methodDropList listItems
 				contains: [ :methodItem | methodItem selector = #useForTestWillBeRemove ])
 	]
-		ensure: [ BIUseForTest
-				compile: 'useForTestWillBeRemove' , String cr , '^ ''klmklm'' '
+		ensure: [ | newMethod |
+			newMethod := BIUseForTest
+				>>
+					(BIUseForTest
+						compile: 'useForTestWillBeRemove' , String cr , '^ ''klmklm'' ').
+			newMethod protocol: 'methods'
 			]
 ]
 
 { #category : #tests }
 BISettingPreviewerTest >> testWhenWeModifiedAMethodInBrowserShouldModifieBeforePrettyPrintTextPresenter [
-	self fail
+	BIUseForTest
+		compile:
+			'useForTestWillBeModified' , String cr
+				, '^ ''what i have in my hat ? A Banana'''.
+	biSettingPreviewer methodDropList
+		selectedIndex:
+			(biSettingPreviewer methodDropList listItems
+				indexOf: BIUseForTest >> #useForTestWillBeModified).
+	self
+		assert: biSettingPreviewer beforePrettyPrintTextPresenter text
+		equals:
+			'useForTestWillBeModified' , String cr
+				, '^ ''what i have in my hat ? A Banana'''
 ]

--- a/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
@@ -207,3 +207,8 @@ BISettingPreviewerTest >> testWhenWeDelateAMethodInBrowserShouldRemoveThisOneFro
 				compile: 'useForTestWillBeRemove' , String cr , '^ ''klmklm'' '
 			]
 ]
+
+{ #category : #tests }
+BISettingPreviewerTest >> testWhenWeModifiedAMethodInBrowserShouldModifieBeforePrettyPrintTextPresenter [
+	self fail
+]

--- a/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BISettingPreviewerTest.class.st
@@ -183,3 +183,27 @@ BISettingPreviewerTest >> testWhenSettingsDropListSelectionShouldChangeTheContex
 		deny: biSettingPreviewer afterPrettyPrintTextPresenter text
 		equals: biSettingPreviewer formatPrettyPrint
 ]
+
+{ #category : #tests }
+BISettingPreviewerTest >> testWhenWeCreatAMethodInBrowserWithTheGoodTagShouldAddThisOneToMethodDropList [
+	[BIUseForTest
+		compile: 'myMethodForTestingAnnouncement' , String cr , '^ ''klmklm'' '.
+	self
+		assert:
+			(biSettingPreviewer methodDropList listItems
+				contains:  [:methodItem |methodItem selector = #myMethodForTestingAnnouncement])]
+			ensure: [(BIUseForTest >>#myMethodForTestingAnnouncement ) removeFromSystem] 
+]
+
+{ #category : #tests }
+BISettingPreviewerTest >> testWhenWeDelateAMethodInBrowserShouldRemoveThisOneFromMethodDropList [
+	[ (BIUseForTest >> #useForTestWillBeRemove) removeFromSystem.
+	self
+		deny:
+			(biSettingPreviewer methodDropList listItems
+				contains: [ :methodItem | methodItem selector = #useForTestWillBeRemove ])
+	]
+		ensure: [ BIUseForTest
+				compile: 'useForTestWillBeRemove' , String cr , '^ ''klmklm'' '
+			]
+]

--- a/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
@@ -156,6 +156,11 @@ BIUseForTest class >> myConfigTest2 [
 }'
 ]
 
+{ #category : #methods }
+BIUseForTest >> useForTestWillBeModified [
+	^ 'what i have in my hat ?'
+]
+
 { #category : #'as yet unclassified' }
 BIUseForTest >> useForTestWillBeRemove [
 ^ 'klmklm' 

--- a/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
@@ -155,3 +155,8 @@ BIUseForTest class >> myConfigTest2 [
 	]
 }'
 ]
+
+{ #category : #'as yet unclassified' }
+BIUseForTest >> useForTestWillBeRemove [
+^ 'klmklm' 
+]

--- a/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
+++ b/MigratePrettyPrinterUI-Tests/BIUseForTest.class.st
@@ -158,10 +158,10 @@ BIUseForTest class >> myConfigTest2 [
 
 { #category : #methods }
 BIUseForTest >> useForTestWillBeModified [
-	^ 'what i have in my hat ?'
+^ 'what i have in my hat ? A Banana'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #methods }
 BIUseForTest >> useForTestWillBeRemove [
 ^ 'klmklm' 
 ]

--- a/MigratePrettyPrinterUI/BIConfigurableFormatter.extension.st
+++ b/MigratePrettyPrinterUI/BIConfigurableFormatter.extension.st
@@ -1,0 +1,6 @@
+Extension { #name : #BIConfigurableFormatter }
+
+{ #category : #'*MigratePrettyPrinterUI' }
+BIConfigurableFormatter class >> defaultPrettyPrintContext [
+	^ DefaultPrettyPrintContext
+]

--- a/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
+++ b/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
@@ -123,21 +123,21 @@ BISettingPreviewer2 >> acceptAction: anInstanceOFBIChooseMethodUI [
 
 { #category : #visiting }
 BISettingPreviewer2 >> acceptActionSBICodePresenter: aBICodePresenter [
-	| string newSettingString newSettingMethod |
+	| string newSettingMethod |
 	string := String
 		streamContents: [ :stream | 
 			stream
-				nextPutAll: aBICodePresenter codePresenter text; cr; tab; nextPutAll: '^ '. 
-					
-					(STON
-						toStringPretty: BIConfigurableFormatter defaultPrettyPrintContext) storeOn: stream  ].
+				nextPutAll: aBICodePresenter codePresenter text;
+				cr;
+				tab;
+				nextPutAll: '^ '.
+			(STON
+				toStringPretty: BIConfigurableFormatter defaultPrettyPrintContext)
+				storeOn: stream
+			].
 	newSettingMethod := methodProvider class
 		>> (methodProvider class compile: string).
-	newSettingMethod protocol: 'settings'.
-	settingsDropList
-		items:
-			(settingsDropList listItems
-				add: newSettingMethod; yourself).
+	newSettingMethod protocol: 'settings'
 ]
 
 { #category : #'initialization-actions' }
@@ -155,28 +155,17 @@ BISettingPreviewer2 >> actionRemoveMethodButton [
 	removeMethodButton
 		action: [ | selectedItem |
 			selectedItem := methodDropList selectedItem.
-			methodDropList
-				items:
-					(methodDropList listItems
-						removeAt: methodDropList selectedIndex; yourself).
 			selectedItem removeFromSystem.
-			methodDropList selectedIndex: 1.
 			self updateAllWidgets ]
 ]
 
 { #category : #'initialization-actions' }
 BISettingPreviewer2 >> actionRemoveSettingButton [
 	removeSettingButton
-		action: [ 
-			settingsDropList selectedItem
+		action: [ settingsDropList selectedItem
 				ifNil: [ self inform: 'please select a confguration' ]
-				ifNotNil: [ :selectedItem | 
-					settingsDropList selectedIndex: 1.
-					settingsDropList
-						items:
-							(settingsDropList listItems 
-								remove: selectedItem; yourself).
-					(methodProvider class >> selectedItem selector) removeFromSystem ] ]
+				ifNotNil: [ :selectedItem | selectedItem removeFromSystem ]
+			]
 ]
 
 { #category : #'initialization-actions' }
@@ -187,11 +176,8 @@ BISettingPreviewer2 >> actionSaveMethodButton [
 				>> (methodProvider compile: beforePrettyPrintTextPresenter text).
 			newMethod protocol: 'methods'.
 			methodDropList
-				items:
-					(methodDropList listItems
-						add: newMethod; yourself).
-			methodDropList
-				selectedIndex: (methodDropList listItems indexOf: newMethod) ]
+				selectedIndex: (methodDropList listItems indexOf: newMethod)
+			]
 ]
 
 { #category : #'initialization-actions' }
@@ -269,6 +255,11 @@ BISettingPreviewer2 >> initialExtent [
 ]
 
 { #category : #initialization }
+BISettingPreviewer2 >> initialize [
+	super initialize
+]
+
+{ #category : #initialization }
 BISettingPreviewer2 >> initializePresenter [
 	self actionMethodDropList.
 	self actionRemoveMethodButton.
@@ -296,7 +287,7 @@ BISettingPreviewer2 >> initializeWidgets [
 	self setupRemoveMethodButton.
 	self setupRemoveSettingButton.
 	self setupSaveSettingButton.
-	self setupMethodDropList.	
+	self setupMethodDropList.
 	self setupSettingsDropList.
 	self setupSettingsTree.
 	self setupChooseMethodUI.
@@ -306,9 +297,30 @@ BISettingPreviewer2 >> initializeWidgets [
 		when: BISettingsChanged
 		send: #whenASettingChanged
 		to: self."
+		self unregisterAnnouncement.
+	SystemAnnouncer uniqueInstance weak
+		when: MethodAdded send: #methodAdded: to: self;
+		when: MethodRemoved send: #methodRemoved: to: self.
+		self announcer when: WindowClosed send: #onWindowClosed to: self.
 	self focusOrder
-		add: settingsTree; add: chooseMethodUI; add: methodDropList; add: beforePrettyPrintTextPresenter; 
-			add: afterPrettyPrintTextPresenter.
+		add: settingsTree;
+		add: chooseMethodUI;
+		add: methodDropList;
+		add: beforePrettyPrintTextPresenter;
+		add: afterPrettyPrintTextPresenter
+]
+
+{ #category : #'system-Announcement' }
+BISettingPreviewer2 >> methodAdded: aMethodAdded [
+	
+	(aMethodAdded methodOrigin = methodProvider
+		or: [ aMethodAdded methodOrigin = methodProvider class ])
+		ifFalse: [ ^ self ].
+	methodDropList
+		items:
+			(methodDropList listItems
+				add: aMethodAdded method;
+				yourself).
 ]
 
 { #category : #accessing }
@@ -324,6 +336,22 @@ BISettingPreviewer2 >> methodProvider [
 { #category : #accessing }
 BISettingPreviewer2 >> methodProvider: anObject [
 	methodProvider := anObject
+]
+
+{ #category : #'system-Announcement' }
+BISettingPreviewer2 >> methodRemoved: aMethodRemoved [
+	aMethodRemoved methodOrigin  = methodProvider 
+		ifFalse: [ ^ self ].
+	methodDropList
+		items:
+			(methodDropList listItems
+				remove: aMethodRemoved method;
+				yourself)
+]
+
+{ #category : #'system-Announcement' }
+BISettingPreviewer2 >> onWindowClosed [
+	self unregisterAnnouncement.
 ]
 
 { #category : #accessing }
@@ -444,6 +472,11 @@ BISettingPreviewer2 >> setupSettingsTree [
 { #category : #api }
 BISettingPreviewer2 >> title [
 	^ 'Blue Ink Setting Previewer'
+]
+
+{ #category : #'system-Announcement' }
+BISettingPreviewer2 >> unregisterAnnouncement [
+SystemAnnouncer uniqueInstance unsubscribe: self  
 ]
 
 { #category : #initialization }

--- a/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
+++ b/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
@@ -13,7 +13,8 @@ Class {
 		'removeSettingButton',
 		'saveSettingButton',
 		'methodProvider',
-		'formaterPrettyPrinter'
+		'formaterPrettyPrinter',
+		'isSettingModification'
 	],
 	#classInstVars : [
 		'methodProvider'
@@ -124,6 +125,7 @@ BISettingPreviewer2 >> acceptAction: anInstanceOFBIChooseMethodUI [
 { #category : #visiting }
 BISettingPreviewer2 >> acceptActionSBICodePresenter: aBICodePresenter [
 	| string newSettingMethod |
+	isSettingModification := true.
 	string := String
 		streamContents: [ :stream | 
 			stream
@@ -137,7 +139,13 @@ BISettingPreviewer2 >> acceptActionSBICodePresenter: aBICodePresenter [
 			].
 	newSettingMethod := methodProvider class
 		>> (methodProvider class compile: string).
-	newSettingMethod protocol: 'settings'
+	newSettingMethod protocol: 'settings'.
+	settingsDropList
+		items:
+			(settingsDropList listItems
+				add: newSettingMethod;
+				yourself).
+	isSettingModification := false
 ]
 
 { #category : #'initialization-actions' }
@@ -162,9 +170,18 @@ BISettingPreviewer2 >> actionRemoveMethodButton [
 { #category : #'initialization-actions' }
 BISettingPreviewer2 >> actionRemoveSettingButton [
 	removeSettingButton
-		action: [ settingsDropList selectedItem
+		action: [ isSettingModification := true.
+			settingsDropList selectedItem
 				ifNil: [ self inform: 'please select a confguration' ]
-				ifNotNil: [ :selectedItem | selectedItem removeFromSystem ]
+				ifNotNil: [ :selectedItem | 
+					selectedItem removeFromSystem.
+					settingsDropList
+						items:
+							(settingsDropList listItems
+								remove: selectedItem;
+								yourself)
+					].
+			isSettingModification := false
 			]
 ]
 
@@ -203,6 +220,11 @@ BISettingPreviewer2 >> actionSettingDropList [
 { #category : #accessing }
 BISettingPreviewer2 >> afterPrettyPrintTextPresenter [
 	^ afterPrettyPrintTextPresenter
+]
+
+{ #category : #accessing }
+BISettingPreviewer2 >> banane [
+	3
 ]
 
 { #category : #accessing }
@@ -252,11 +274,6 @@ BISettingPreviewer2 >> formaterPrettyPrinter [
 { #category : #api }
 BISettingPreviewer2 >> initialExtent [
 	^ 1000 @ 700
-]
-
-{ #category : #initialization }
-BISettingPreviewer2 >> initialize [
-	super initialize
 ]
 
 { #category : #initialization }
@@ -312,15 +329,16 @@ BISettingPreviewer2 >> initializeWidgets [
 
 { #category : #'system-Announcement' }
 BISettingPreviewer2 >> methodAdded: aMethodAdded [
-	
-	(aMethodAdded methodOrigin = methodProvider
-		or: [ aMethodAdded methodOrigin = methodProvider class ])
+	(isSettingModification not
+		and: [ aMethodAdded methodOrigin = methodProvider
+				or: [ aMethodAdded methodOrigin = methodProvider class ]
+			])
 		ifFalse: [ ^ self ].
 	methodDropList
 		items:
 			(methodDropList listItems
 				add: aMethodAdded method;
-				yourself).
+				yourself)
 ]
 
 { #category : #accessing }
@@ -340,7 +358,8 @@ BISettingPreviewer2 >> methodProvider: anObject [
 
 { #category : #'system-Announcement' }
 BISettingPreviewer2 >> methodRemoved: aMethodRemoved [
-	aMethodRemoved methodOrigin  = methodProvider 
+	(aMethodRemoved methodOrigin = methodProvider
+		and: [ isSettingModification not ])
 		ifFalse: [ ^ self ].
 	methodDropList
 		items:
@@ -487,6 +506,5 @@ BISettingPreviewer2 >> updateAllWidgets [
 
 { #category : #'event handling' }
 BISettingPreviewer2 >> whenASettingChanged [
-	(self formattedCheckBox state and: [ self selectorAndClassAreCorrect ])
-		ifTrue: [ self formatSourceCode ] 
+	afterPrettyPrintTextPresenter text: self formatPrettyPrint 
 ]

--- a/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
+++ b/MigratePrettyPrinterUI/BISettingPreviewer2.class.st
@@ -175,6 +175,7 @@ BISettingPreviewer2 >> actionRemoveSettingButton [
 				ifNil: [ self inform: 'please select a confguration' ]
 				ifNotNil: [ :selectedItem | 
 					selectedItem removeFromSystem.
+					settingsDropList selectedIndex: 1.
 					settingsDropList
 						items:
 							(settingsDropList listItems
@@ -192,8 +193,7 @@ BISettingPreviewer2 >> actionSaveMethodButton [
 			newMethod := methodProvider
 				>> (methodProvider compile: beforePrettyPrintTextPresenter text).
 			newMethod protocol: 'methods'.
-			methodDropList
-				selectedIndex: (methodDropList listItems indexOf: newMethod)
+			methodDropList selectedIndex: 1
 			]
 ]
 
@@ -277,6 +277,12 @@ BISettingPreviewer2 >> initialExtent [
 ]
 
 { #category : #initialization }
+BISettingPreviewer2 >> initialize [
+	isSettingModification := false.
+	super initialize 
+]
+
+{ #category : #initialization }
 BISettingPreviewer2 >> initializePresenter [
 	self actionMethodDropList.
 	self actionRemoveMethodButton.
@@ -329,10 +335,10 @@ BISettingPreviewer2 >> initializeWidgets [
 
 { #category : #'system-Announcement' }
 BISettingPreviewer2 >> methodAdded: aMethodAdded [
+	isSettingModification ifNil: [ isSettingModification := false ].
 	(isSettingModification not
 		and: [ aMethodAdded methodOrigin = methodProvider
-				or: [ aMethodAdded methodOrigin = methodProvider class ]
-			])
+				or: [ aMethodAdded methodOrigin = methodProvider class ] ])
 		ifFalse: [ ^ self ].
 	methodDropList
 		items:
@@ -361,6 +367,7 @@ BISettingPreviewer2 >> methodRemoved: aMethodRemoved [
 	(aMethodRemoved methodOrigin = methodProvider
 		and: [ isSettingModification not ])
 		ifFalse: [ ^ self ].
+	methodDropList selectedIndex: 1.
 	methodDropList
 		items:
 			(methodDropList listItems


### PR DESCRIPTION
add subscription to MethodAdded and MethodRemove when you add/remove method from the browser it will add/remove from the method dropList